### PR TITLE
Use source-inplace to test unsaved buffers

### DIFF
--- a/flycheck-jest.el
+++ b/flycheck-jest.el
@@ -75,7 +75,7 @@
   :command ("jest"
             "--json"
             "--testPathPattern"
-            (eval buffer-file-name)
+            source-inplace
             "--outputFile"
             (eval (flycheck-jest--result-path)))
   :error-parser flycheck-jest--parse


### PR DESCRIPTION
This allows the test run to be accurate even if the file has not been saved.