### PR TITLE
Fix jest error parsing & misc improvements/changes

### DIFF
--- a/flycheck-jest.el
+++ b/flycheck-jest.el
@@ -174,8 +174,8 @@ Result is a list of plists with the form:
             (mapcar
              (lambda (s)
                (cond
-                ((string-match-p "at Object.<anonymous>" s)
-                 (let* ((split (split-string s "at Object.<anonymous>" t))
+                ((string-match-p "at Object." s)
+                 (let* ((split (split-string s "at Object." t))
                         (error-message (string-trim (car split)))
                         (linenumbers-str (cadr split))
                         (line (flycheck-jest--extract-line linenumbers-str))

--- a/flycheck-jest.el
+++ b/flycheck-jest.el
@@ -66,7 +66,7 @@
 (flycheck-def-executable-var jest "jest")
 
 (flycheck-def-option-var flycheck-jest-extra-flags nil jest
-  "Extra flags prepended to arguments of jest."
+  "Extra flags appended to arguments of jest."
   :type '(repeat (string :tag "Flags"))
   :safe #'flycheck-string-list-p)
 
@@ -77,7 +77,8 @@
             "--testPathPattern"
             (eval buffer-file-name)
             "--outputFile"
-            (eval (flycheck-jest--result-path)))
+            (eval (flycheck-jest--result-path))
+            (eval flycheck-jest-extra-flags))
   :error-parser flycheck-jest--parse
   :modes (web-mode js-mode typescript-mode rjsx-mode)
   :predicate

--- a/flycheck-jest.el
+++ b/flycheck-jest.el
@@ -53,12 +53,6 @@
   "A `flycheck' extension for jest."
   :group 'programming)
 
-(defcustom flycheck-jest-report-directory
-  (format "%s.jest-reports" user-emacs-directory)
-  "Where jest stores results for each test run."
-  :type 'string
-  :group 'flycheck-jest)
-
 ;;; Flycheck
 (defvar flycheck-jest-modes '(web-mode js-mode typescript-mode rjsx-mode)
   "A list of modes for use with `flycheck-jest'.")
@@ -122,19 +116,6 @@
        (file-exists-p
         (format "%snode_modules/.bin/jest"
                 (flycheck-jest--find-jest-project-directory)))))
-
-(defun flycheck-jest--result-path (&optional buffer)
-  "Return the path `flycheck-jest' writes json reports to.
-
-If BUFFER is not nil, use that to determine the base of the file name."
-  (unless (file-exists-p flycheck-jest-report-directory)
-    (make-directory flycheck-jest-report-directory))
-  (let ((base-name
-         (file-name-base (if buffer
-                             (buffer-file-name buffer)
-                           buffer-file-name))))
-    (expand-file-name (format "%s/%s-report.json"
-                              flycheck-jest-report-directory base-name))))
 
 (defun flycheck-jest--parse (output checker buffer)
   "`flycheck' parser for jest output.


### PR DESCRIPTION
Jest now outputs slightly different (more accurate) error pointers, with the `<anonymous>` part being replaced by the exact failing matcher (i.e. `Object.toBe`, `Object.toEqual`, etc.). The regex was relaxed to handle it.

`flycheck-jest-extra-flags` appears to have been dropped from the command invocation, so it was re-added to the end.

The two last commits are purely optional and I'd be happy to drop them or put them on a separate PR. They remove the reliance on generated json files, reading the json entry directly from the process using Flycheck's "native" helpers. It made some code unused, which got removed.

Thanks for writing this in the first place! 
Reading your code was super helpful in understanding how flycheck works!